### PR TITLE
Add :root CSS variables for typography styles

### DIFF
--- a/dist/css/equilibrium.css
+++ b/dist/css/equilibrium.css
@@ -1,3 +1,11 @@
+:root {
+  --eq-font-family-base: Roboto, Arial, Helvetica, sans-serif;
+  --eq-font-family-code: Consolas, "Courier New", Courier, monospace;
+  --eq-font-size-base: 1rem;
+  --eq-font-weight-base: 400;
+  --eq-line-height-base: 1.5;
+}
+
 /* Set up a box model on the root element */
 html {
   box-sizing: border-box;

--- a/dist/css/equilibrium.css.map
+++ b/dist/css/equilibrium.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../../src/scss/_reset.scss"],"names":[],"mappings":"AAGA;AACA;EACE;;;AAGF;AAAA;AAAA;AAAA;AAIA;AAAA;AAAA;EAGE;EACA;EACA;;;AAGF;AACA;EACE;;;AAGF;AACA;EACE;EACA","file":"equilibrium.css"}
+{"version":3,"sourceRoot":"","sources":["../../src/scss/_root.scss","../../src/scss/_reset.scss"],"names":[],"mappings":"AAGA;EACE;EACA;EACA;EACA;EACA;;;ACLF;AACA;EACE;;;AAGF;AAAA;AAAA;AAAA;AAIA;AAAA;AAAA;EAGE;EACA;EACA;;;AAGF;AACA;EACE;;;AAGF;AACA;EACE;EACA","file":"equilibrium.css"}

--- a/src/scss/_root.scss
+++ b/src/scss/_root.scss
@@ -1,0 +1,10 @@
+// This file is used to define the global (root) CSS variables.
+// -----------------------------------------------------------------------------
+
+:root {
+  --#{$prefix}font-family-base: #{inspect($font-family-sans-serif)};
+  --#{$prefix}font-family-code: #{inspect($font-family-monospace)};
+  --#{$prefix}font-size-base: #{$font-size-base};
+  --#{$prefix}font-weight-base: #{$font-weight-normal};
+  --#{$prefix}line-height-base: #{$line-height-base};
+}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,3 +1,7 @@
+// Equilibrium prefix for :root CSS variables
+
+$prefix: eq- !default;
+
 // Breakpoints
 
 /// Map of breakpoints for responsive design.

--- a/src/scss/equilibrium.scss
+++ b/src/scss/equilibrium.scss
@@ -5,4 +5,6 @@
 @import 'breakpoints';
 
 // Base
-@import 'reset';
+@import
+  'root',
+  'reset';


### PR DESCRIPTION
- create a custom Equilibrium prefix and save it as a `$prefix` variable
- add :root CSS variables for typography styles